### PR TITLE
Ship alexa-poller companion binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 BINARY_NAME=alexacli
+POLLER_BINARY_NAME=alexa-poller
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_TIME=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS=-ldflags "-X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME)"
 
-.PHONY: build install clean test
+.PHONY: build build-poller build-tools install clean test
 
 build:
 	go build $(LDFLAGS) -o bin/$(BINARY_NAME) ./cmd/alexa
+
+build-poller:
+	go build -ldflags "-X main.version=$(VERSION)" -o bin/$(POLLER_BINARY_NAME) ./cmd/alexa-poller
+
+build-tools: build build-poller
 
 install: build
 	cp bin/$(BINARY_NAME) /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ brew install buddyh/tap/alexacli
 
 ```bash
 go install github.com/buddyh/alexa-cli/cmd/alexa@latest
+go install github.com/buddyh/alexa-cli/cmd/alexa-poller@latest
 ```
 
 ### Build locally
@@ -25,6 +26,9 @@ git clone https://github.com/buddyh/alexa-cli
 cd alexa-cli
 make build
 ./bin/alexacli --help
+
+make build-poller
+./bin/alexa-poller --help
 ```
 
 ## Authentication
@@ -243,6 +247,36 @@ Output shows both your messages (USER) and Alexa's responses (ALEXA):
 - Source citations when applicable
 
 > **Note:** Requires Alexa+ to be enabled on your Amazon account.
+
+### Activation Phrase Poller
+
+`alexa-poller` is a companion binary for route-based voice automation. It listens for activation phrases in Alexa activity and dispatches the remaining text to a destination such as OpenClaw, a shell command, or stdout.
+
+The default source mode is `auto`, which prefers Alexa+ conversation fragments when available and falls back to voice history for compatibility.
+
+```bash
+# Route "clawtto ..." from one device into OpenClaw
+alexa-poller route add clawtto --device "Echo Show" --to openclaw:main --source auto
+
+# Print matched payloads instead of dispatching them
+alexa-poller route add house --to stdout
+
+# Execute a shell command with the matched text
+alexa-poller route add brief me --to 'exec:/Users/buddy/bin/dispatch "{{text}}"'
+
+# Review configured routes
+alexa-poller route list
+
+# Run the poller
+alexa-poller run
+```
+
+Route behavior:
+- Default match mode is `prefix`, so `clawtto summarize my unread emails` dispatches `summarize my unread emails`.
+- Built-in ignore phrases include `nevermind` and `ignore this`.
+- Optional acknowledgements can be spoken back on the originating device with `--ack`.
+
+The poller stores route config in `~/.alexa-cli/poller.json` and its dedupe state in `~/.alexa-cli/poller-state.json`.
 
 ### Audio Playback
 

--- a/cmd/alexa-poller/main.go
+++ b/cmd/alexa-poller/main.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/buddyh/alexa-cli/internal/api"
+	"github.com/buddyh/alexa-cli/internal/config"
+	"github.com/buddyh/alexa-cli/internal/watch"
+	"github.com/spf13/cobra"
+)
+
+var version = "dev"
+
+func main() {
+	if err := execute(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func execute(args []string) error {
+	root := &cobra.Command{
+		Use:           "alexa-poller",
+		Short:         "Listen for Alexa activation phrases and route them to automations",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Version:       version,
+	}
+
+	root.AddCommand(newRouteCmd())
+	root.AddCommand(newRunCmd())
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+func newRouteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "route",
+		Short: "Manage activation phrase routes",
+	}
+	cmd.AddCommand(newRouteAddCmd())
+	cmd.AddCommand(newRouteListCmd())
+	cmd.AddCommand(newRouteRemoveCmd())
+	return cmd
+}
+
+func newRouteAddCmd() *cobra.Command {
+	var device string
+	var source string
+	var destination string
+	var ack string
+	var ignore []string
+	var match string
+
+	cmd := &cobra.Command{
+		Use:   "add <phrase>",
+		Short: "Add an activation phrase route",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := watch.LoadConfig()
+			if err != nil {
+				return err
+			}
+
+			action, err := parseDestination(destination)
+			if err != nil {
+				return err
+			}
+
+			route := watch.Route{
+				Phrase: args[0],
+				Device: device,
+				Source: watch.Source(source),
+				Match:  watch.Match(match),
+				Ignore: ignore,
+				Action: action,
+			}
+			if ack != "" {
+				route.Ack = &watch.Ack{Text: ack}
+			}
+			if err := route.Normalize(); err != nil {
+				return err
+			}
+
+			cfg.Routes = append(cfg.Routes, route)
+			if err := watch.SaveConfig(cfg); err != nil {
+				return err
+			}
+
+			fmt.Printf("Added route %s for phrase %q\n", route.ID, route.Phrase)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&device, "device", "", "Limit matches to one Alexa device")
+	cmd.Flags().StringVar(&source, "source", string(watch.SourceAuto), "Source backend: auto, conversation, history")
+	cmd.Flags().StringVar(&destination, "to", "openclaw:main", "Route destination, e.g. openclaw:main, exec:/path/to/script '{{text}}', stdout")
+	cmd.Flags().StringVar(&ack, "ack", "", "Optional Alexa acknowledgement text")
+	cmd.Flags().StringSliceVar(&ignore, "ignore", nil, "Additional ignore phrases")
+	cmd.Flags().StringVar(&match, "match", string(watch.MatchPrefix), "Phrase match mode: prefix or contains")
+	return cmd
+}
+
+func newRouteListCmd() *cobra.Command {
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List configured routes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := watch.LoadConfig()
+			if err != nil {
+				return err
+			}
+
+			if asJSON {
+				data, err := json.MarshalIndent(cfg.Routes, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(data))
+				return nil
+			}
+
+			if len(cfg.Routes) == 0 {
+				fmt.Println("No routes configured.")
+				return nil
+			}
+
+			for _, route := range cfg.Routes {
+				dest := string(route.Action.Type)
+				switch route.Action.Type {
+				case watch.ActionOpenClaw:
+					dest += ":" + route.Action.Agent
+				case watch.ActionExec:
+					dest += ":" + route.Action.Command
+				}
+				fmt.Printf("%s  phrase=%q device=%q source=%s dest=%s\n",
+					route.ID, route.Phrase, route.Device, route.Source, dest)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Output routes as JSON")
+	return cmd
+}
+
+func newRouteRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <route-id>",
+		Short: "Remove a configured route",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := watch.LoadConfig()
+			if err != nil {
+				return err
+			}
+
+			routeID := args[0]
+			filtered := make([]watch.Route, 0, len(cfg.Routes))
+			removed := false
+			for _, route := range cfg.Routes {
+				if route.ID == routeID {
+					removed = true
+					continue
+				}
+				filtered = append(filtered, route)
+			}
+			if !removed {
+				return fmt.Errorf("route %q not found", routeID)
+			}
+
+			cfg.Routes = filtered
+			if err := watch.SaveConfig(cfg); err != nil {
+				return err
+			}
+
+			fmt.Printf("Removed route %s\n", routeID)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run the Alexa poller",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pollerCfg, err := watch.LoadConfig()
+			if err != nil {
+				return err
+			}
+			if len(pollerCfg.Routes) == 0 {
+				return fmt.Errorf("no routes configured. Add one with 'alexa-poller route add'")
+			}
+
+			state, err := watch.LoadState()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			client, err := api.NewClient(cfg.RefreshToken, cfg.AmazonDomain)
+			if err != nil {
+				return err
+			}
+
+			runner := &watch.Runner{
+				Client: client,
+				Config: pollerCfg,
+				State:  state,
+			}
+
+			fmt.Printf("Running Alexa poller with %d route(s) every %s\n", len(pollerCfg.Routes), pollerCfg.PollEvery())
+			return runner.Run(context.Background())
+		},
+	}
+	return cmd
+}
+
+func parseDestination(value string) (watch.Action, error) {
+	value = strings.TrimSpace(value)
+	switch {
+	case value == "", value == "stdout":
+		return watch.Action{Type: watch.ActionStdout}, nil
+	case strings.HasPrefix(value, "openclaw"):
+		action := watch.Action{Type: watch.ActionOpenClaw, Agent: "main"}
+		if idx := strings.Index(value, ":"); idx >= 0 && idx+1 < len(value) {
+			action.Agent = strings.TrimSpace(value[idx+1:])
+			if action.Agent == "" {
+				action.Agent = "main"
+			}
+		}
+		return action, nil
+	case strings.HasPrefix(value, "exec:"):
+		command := strings.TrimSpace(strings.TrimPrefix(value, "exec:"))
+		if command == "" {
+			return watch.Action{}, fmt.Errorf("exec destination requires a command")
+		}
+		return watch.Action{Type: watch.ActionExec, Command: command}, nil
+	default:
+		return watch.Action{}, fmt.Errorf("unsupported destination %q", value)
+	}
+}

--- a/cmd/alexa-poller/main_test.go
+++ b/cmd/alexa-poller/main_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buddyh/alexa-cli/internal/watch"
+)
+
+func TestParseDestination(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    watch.Action
+		wantErr bool
+	}{
+		{
+			name:  "stdout",
+			value: "stdout",
+			want:  watch.Action{Type: watch.ActionStdout},
+		},
+		{
+			name:  "empty defaults to stdout",
+			value: "",
+			want:  watch.Action{Type: watch.ActionStdout},
+		},
+		{
+			name:  "openclaw default agent",
+			value: "openclaw",
+			want:  watch.Action{Type: watch.ActionOpenClaw, Agent: "main"},
+		},
+		{
+			name:  "openclaw explicit agent",
+			value: "openclaw:nightly",
+			want:  watch.Action{Type: watch.ActionOpenClaw, Agent: "nightly"},
+		},
+		{
+			name:  "exec command",
+			value: "exec:/usr/local/bin/dispatch '{{text}}'",
+			want:  watch.Action{Type: watch.ActionExec, Command: "/usr/local/bin/dispatch '{{text}}'"},
+		},
+		{
+			name:    "empty exec command",
+			value:   "exec: ",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported",
+			value:   "webhook:https://example.test",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDestination(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse destination: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("action = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouteCommandsManageConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := execute([]string{
+		"route", "add", "clawtto",
+		"--device", "Echo Show",
+		"--source", "history",
+		"--match", "contains",
+		"--to", "stdout",
+		"--ack", "On it",
+		"--ignore", "stand down",
+	}); err != nil {
+		t.Fatalf("route add: %v", err)
+	}
+
+	routes := loadRoutesForTest(t, home)
+	if len(routes) != 1 {
+		t.Fatalf("routes len = %d, want 1", len(routes))
+	}
+	route := routes[0]
+	if route.ID == "" {
+		t.Fatalf("route ID was not generated")
+	}
+	if got, want := route.Phrase, "clawtto"; got != want {
+		t.Fatalf("phrase = %q, want %q", got, want)
+	}
+	if got, want := route.Device, "Echo Show"; got != want {
+		t.Fatalf("device = %q, want %q", got, want)
+	}
+	if got, want := route.Source, watch.SourceHistory; got != want {
+		t.Fatalf("source = %q, want %q", got, want)
+	}
+	if got, want := route.Match, watch.MatchContains; got != want {
+		t.Fatalf("match = %q, want %q", got, want)
+	}
+	if got, want := route.Action.Type, watch.ActionStdout; got != want {
+		t.Fatalf("action type = %q, want %q", got, want)
+	}
+	if route.Ack == nil || route.Ack.Text != "On it" {
+		t.Fatalf("ack = %#v, want text", route.Ack)
+	}
+
+	if err := execute([]string{"route", "list", "--json"}); err != nil {
+		t.Fatalf("route list: %v", err)
+	}
+	if err := execute([]string{"route", "remove", route.ID}); err != nil {
+		t.Fatalf("route remove: %v", err)
+	}
+	routes = loadRoutesForTest(t, home)
+	if len(routes) != 0 {
+		t.Fatalf("routes len after remove = %d, want 0", len(routes))
+	}
+}
+
+func TestRouteRemoveMissingRouteFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := execute([]string{"route", "remove", "route-missing"}); err == nil {
+		t.Fatalf("expected missing route error")
+	}
+}
+
+func loadRoutesForTest(t *testing.T, home string) []watch.Route {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(home, ".alexa-cli", "poller.json"))
+	if err != nil {
+		t.Fatalf("read poller config: %v", err)
+	}
+	var cfg watch.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse poller config: %v", err)
+	}
+	return cfg.Routes
+}

--- a/cmd/alexa/smarthome.go
+++ b/cmd/alexa/smarthome.go
@@ -11,9 +11,9 @@ import (
 
 func newSmartHomeCmd(flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "smarthome",
-		Short: "Control smart home devices",
-		Long:  `List and control smart home devices connected to Alexa.`,
+		Use:     "smarthome",
+		Short:   "Control smart home devices",
+		Long:    `List and control smart home devices connected to Alexa.`,
 		Aliases: []string{"sh", "home"},
 	}
 

--- a/internal/watch/config.go
+++ b/internal/watch/config.go
@@ -1,0 +1,334 @@
+package watch
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/buddyh/alexa-cli/internal/config"
+)
+
+const (
+	configFileName = "poller.json"
+	stateFileName  = "poller-state.json"
+)
+
+var defaultIgnorePhrases = []string{
+	"nevermind",
+	"ignore this",
+}
+
+// Config holds the poller routes and runtime defaults.
+type Config struct {
+	PollInterval string  `json:"pollInterval,omitempty"`
+	Routes       []Route `json:"routes"`
+}
+
+// Route describes one activation phrase route.
+type Route struct {
+	ID     string   `json:"id"`
+	Phrase string   `json:"phrase"`
+	Device string   `json:"device,omitempty"`
+	Source Source   `json:"source,omitempty"`
+	Match  Match    `json:"match,omitempty"`
+	Ignore []string `json:"ignore,omitempty"`
+	Action Action   `json:"action"`
+	Ack    *Ack     `json:"ack,omitempty"`
+}
+
+// Source identifies the watcher backend.
+type Source string
+
+const (
+	SourceAuto         Source = "auto"
+	SourceHistory      Source = "history"
+	SourceConversation Source = "conversation"
+)
+
+// Match identifies how a route phrase should be matched.
+type Match string
+
+const (
+	MatchPrefix   Match = "prefix"
+	MatchContains Match = "contains"
+)
+
+// Action is the destination invoked for a matched route.
+type Action struct {
+	Type    ActionType `json:"type"`
+	Agent   string     `json:"agent,omitempty"`
+	Command string     `json:"command,omitempty"`
+}
+
+// ActionType identifies the supported route actions.
+type ActionType string
+
+const (
+	ActionOpenClaw ActionType = "openclaw"
+	ActionExec     ActionType = "exec"
+	ActionStdout   ActionType = "stdout"
+)
+
+// Ack configures an optional Alexa acknowledgement.
+type Ack struct {
+	Text string `json:"text"`
+}
+
+// State tracks seen records so the poller can survive restarts.
+type State struct {
+	SeenHistory      map[string]int64  `json:"seenHistory"`
+	SeenConversation map[string]string `json:"seenConversation"`
+}
+
+// Event is a normalized match candidate emitted by a watcher backend.
+type Event struct {
+	Source       Source
+	RouteSource  Source
+	Key          string
+	Conversation string
+	DeviceName   string
+	DeviceSerial string
+	Timestamp    time.Time
+	Text         string
+	RawText      string
+}
+
+// ConfigPath returns the poller config path.
+func ConfigPath() (string, error) {
+	dir, err := config.Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, configFileName), nil
+}
+
+// StatePath returns the poller state path.
+func StatePath() (string, error) {
+	dir, err := config.Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, stateFileName), nil
+}
+
+// LoadConfig reads the poller config from disk. Missing config is valid.
+func LoadConfig() (*Config, error) {
+	path, err := ConfigPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{}, nil
+		}
+		return nil, fmt.Errorf("failed to read poller config: %w", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse poller config: %w", err)
+	}
+
+	for i := range cfg.Routes {
+		if err := cfg.Routes[i].Normalize(); err != nil {
+			return nil, fmt.Errorf("route %d: %w", i+1, err)
+		}
+	}
+
+	return &cfg, nil
+}
+
+// SaveConfig writes the poller config to disk.
+func SaveConfig(cfg *Config) error {
+	for i := range cfg.Routes {
+		if err := cfg.Routes[i].Normalize(); err != nil {
+			return fmt.Errorf("route %d: %w", i+1, err)
+		}
+	}
+
+	dir, err := config.Dir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal poller config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write poller config: %w", err)
+	}
+	return nil
+}
+
+// LoadState reads the persisted watcher state from disk.
+func LoadState() (*State, error) {
+	path, err := StatePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return NewState(), nil
+		}
+		return nil, fmt.Errorf("failed to read poller state: %w", err)
+	}
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to parse poller state: %w", err)
+	}
+
+	if state.SeenHistory == nil {
+		state.SeenHistory = make(map[string]int64)
+	}
+	if state.SeenConversation == nil {
+		state.SeenConversation = make(map[string]string)
+	}
+
+	return &state, nil
+}
+
+// Save writes the state file to disk.
+func (s *State) Save() error {
+	dir, err := config.Dir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	path, err := StatePath()
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal poller state: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write poller state: %w", err)
+	}
+	return nil
+}
+
+// NewState returns an initialized empty state.
+func NewState() *State {
+	return &State{
+		SeenHistory:      make(map[string]int64),
+		SeenConversation: make(map[string]string),
+	}
+}
+
+// PollEvery returns the configured poll interval.
+func (c *Config) PollEvery() time.Duration {
+	if c.PollInterval == "" {
+		return 5 * time.Second
+	}
+	d, err := time.ParseDuration(c.PollInterval)
+	if err != nil || d <= 0 {
+		return 5 * time.Second
+	}
+	return d
+}
+
+// Normalize validates and fills route defaults.
+func (r *Route) Normalize() error {
+	r.Phrase = strings.TrimSpace(r.Phrase)
+	if r.Phrase == "" {
+		return fmt.Errorf("phrase is required")
+	}
+	if r.ID == "" {
+		r.ID = newRouteID()
+	}
+
+	if r.Source == "" {
+		r.Source = SourceAuto
+	}
+	switch r.Source {
+	case SourceAuto, SourceHistory, SourceConversation:
+	default:
+		return fmt.Errorf("unsupported source %q", r.Source)
+	}
+
+	if r.Match == "" {
+		r.Match = MatchPrefix
+	}
+	switch r.Match {
+	case MatchPrefix, MatchContains:
+	default:
+		return fmt.Errorf("unsupported match mode %q", r.Match)
+	}
+
+	if r.Action.Type == "" {
+		r.Action.Type = ActionOpenClaw
+	}
+	switch r.Action.Type {
+	case ActionOpenClaw:
+	case ActionExec:
+		if strings.TrimSpace(r.Action.Command) == "" {
+			return fmt.Errorf("exec action requires a command")
+		}
+	case ActionStdout:
+	default:
+		return fmt.Errorf("unsupported action type %q", r.Action.Type)
+	}
+
+	r.Device = strings.TrimSpace(r.Device)
+	normalizedIgnore := make([]string, 0, len(defaultIgnorePhrases)+len(r.Ignore))
+	seen := make(map[string]struct{})
+	for _, phrase := range append(defaultIgnorePhrases, r.Ignore...) {
+		phrase = normalizePhrase(phrase)
+		if phrase == "" {
+			continue
+		}
+		if _, ok := seen[phrase]; ok {
+			continue
+		}
+		seen[phrase] = struct{}{}
+		normalizedIgnore = append(normalizedIgnore, phrase)
+	}
+	r.Ignore = normalizedIgnore
+
+	if r.Action.Type == ActionOpenClaw && strings.TrimSpace(r.Action.Agent) == "" {
+		r.Action.Agent = "main"
+	}
+
+	if r.Ack != nil {
+		r.Ack.Text = strings.TrimSpace(r.Ack.Text)
+		if r.Ack.Text == "" {
+			r.Ack = nil
+		}
+	}
+
+	return nil
+}
+
+func newRouteID() string {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err == nil {
+		return "route-" + hex.EncodeToString(buf)
+	}
+	return fmt.Sprintf("route-%d", time.Now().UnixNano())
+}

--- a/internal/watch/config_test.go
+++ b/internal/watch/config_test.go
@@ -1,6 +1,11 @@
 package watch
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 func TestMatchEventPrefix(t *testing.T) {
 	route := Route{
@@ -41,6 +46,38 @@ func TestMatchEventIgnoresMetaCommentary(t *testing.T) {
 	}
 }
 
+func TestMatchEventContainsWithDeviceFilter(t *testing.T) {
+	route := Route{
+		Phrase: "brief me",
+		Device: "Kitchen Echo",
+		Match:  MatchContains,
+		Action: Action{Type: ActionStdout},
+	}
+	if err := route.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	if _, ok := MatchEvent(route, Event{
+		DeviceName: "Office Echo",
+		Text:       "Alexa, brief me on the release",
+		RawText:    "Alexa, brief me on the release",
+	}); ok {
+		t.Fatalf("expected mismatched device to be ignored")
+	}
+
+	payload, ok := MatchEvent(route, Event{
+		DeviceName: "Kitchen Echo",
+		Text:       "Alexa, brief me on the release",
+		RawText:    "Alexa, brief me on the release",
+	})
+	if !ok {
+		t.Fatalf("expected route to match")
+	}
+	if want := "on the release"; payload != want {
+		t.Fatalf("payload = %q, want %q", payload, want)
+	}
+}
+
 func TestNormalizeRouteDefaults(t *testing.T) {
 	route := Route{
 		Phrase: "clawtto",
@@ -57,5 +94,121 @@ func TestNormalizeRouteDefaults(t *testing.T) {
 	}
 	if route.Action.Agent != "main" {
 		t.Fatalf("agent = %q, want main", route.Action.Agent)
+	}
+	if len(route.Ignore) != len(defaultIgnorePhrases) {
+		t.Fatalf("ignore count = %d, want %d", len(route.Ignore), len(defaultIgnorePhrases))
+	}
+}
+
+func TestNormalizeRouteValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		route Route
+	}{
+		{
+			name:  "missing phrase",
+			route: Route{Action: Action{Type: ActionStdout}},
+		},
+		{
+			name:  "invalid source",
+			route: Route{Phrase: "clawtto", Source: "rss", Action: Action{Type: ActionStdout}},
+		},
+		{
+			name:  "invalid match",
+			route: Route{Phrase: "clawtto", Match: "regex", Action: Action{Type: ActionStdout}},
+		},
+		{
+			name:  "exec without command",
+			route: Route{Phrase: "clawtto", Action: Action{Type: ActionExec}},
+		},
+		{
+			name:  "invalid action",
+			route: Route{Phrase: "clawtto", Action: Action{Type: "webhook"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.route.Normalize(); err == nil {
+				t.Fatalf("expected validation error")
+			}
+		})
+	}
+}
+
+func TestConfigAndStateRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &Config{
+		PollInterval: "250ms",
+		Routes: []Route{
+			{
+				Phrase: "clawtto",
+				Device: "Echo Show",
+				Ignore: []string{"stand down", "stand down"},
+				Action: Action{Type: ActionExec, Command: "printf %s {{text}}"},
+				Ack:    &Ack{Text: "Sent"},
+			},
+		},
+	}
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	path := filepath.Join(home, ".alexa-cli", configFileName)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Fatalf("config mode = %v, want 0600", mode)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if got, want := loaded.PollEvery(), 250*time.Millisecond; got != want {
+		t.Fatalf("poll interval = %v, want %v", got, want)
+	}
+	if len(loaded.Routes) != 1 {
+		t.Fatalf("routes len = %d, want 1", len(loaded.Routes))
+	}
+	route := loaded.Routes[0]
+	if route.ID == "" {
+		t.Fatalf("route ID was not generated")
+	}
+	if got, want := route.Action.Command, "printf %s {{text}}"; got != want {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+	if got, want := len(route.Ignore), len(defaultIgnorePhrases)+1; got != want {
+		t.Fatalf("ignore count = %d, want %d", got, want)
+	}
+
+	state := NewState()
+	state.SeenHistory["record-1"] = 123
+	state.SeenConversation["fragment-1"] = "conversation-1"
+	if err := state.Save(); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	loadedState, err := LoadState()
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if got, want := loadedState.SeenHistory["record-1"], int64(123); got != want {
+		t.Fatalf("seen history = %d, want %d", got, want)
+	}
+	if got, want := loadedState.SeenConversation["fragment-1"], "conversation-1"; got != want {
+		t.Fatalf("seen conversation = %q, want %q", got, want)
+	}
+}
+
+func TestPollEveryFallbacks(t *testing.T) {
+	for _, interval := range []string{"", "nope", "-1s", "0s"} {
+		cfg := Config{PollInterval: interval}
+		if got, want := cfg.PollEvery(), 5*time.Second; got != want {
+			t.Fatalf("PollEvery(%q) = %v, want %v", interval, got, want)
+		}
 	}
 }

--- a/internal/watch/config_test.go
+++ b/internal/watch/config_test.go
@@ -1,0 +1,61 @@
+package watch
+
+import "testing"
+
+func TestMatchEventPrefix(t *testing.T) {
+	route := Route{
+		Phrase: "clawtto",
+		Action: Action{Type: ActionStdout},
+	}
+	if err := route.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	payload, ok := MatchEvent(route, Event{
+		DeviceName: "Echo Show",
+		Text:       "Clawtto can you summarize my unread emails",
+		RawText:    "Clawtto can you summarize my unread emails",
+	})
+	if !ok {
+		t.Fatalf("expected route to match")
+	}
+	if want := "summarize my unread emails"; payload != want {
+		t.Fatalf("payload = %q, want %q", payload, want)
+	}
+}
+
+func TestMatchEventIgnoresMetaCommentary(t *testing.T) {
+	route := Route{
+		Phrase: "clawtto",
+		Action: Action{Type: ActionStdout},
+	}
+	if err := route.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	if _, ok := MatchEvent(route, Event{
+		Text:    "nevermind clawtto send this to openclaw",
+		RawText: "nevermind clawtto send this to openclaw",
+	}); ok {
+		t.Fatalf("expected nevermind phrase to be ignored")
+	}
+}
+
+func TestNormalizeRouteDefaults(t *testing.T) {
+	route := Route{
+		Phrase: "clawtto",
+		Action: Action{Type: ActionOpenClaw},
+	}
+	if err := route.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if route.Source != SourceAuto {
+		t.Fatalf("source = %q, want %q", route.Source, SourceAuto)
+	}
+	if route.Match != MatchPrefix {
+		t.Fatalf("match = %q, want %q", route.Match, MatchPrefix)
+	}
+	if route.Action.Agent != "main" {
+		t.Fatalf("agent = %q, want main", route.Action.Agent)
+	}
+}

--- a/internal/watch/match.go
+++ b/internal/watch/match.go
@@ -1,0 +1,95 @@
+package watch
+
+import (
+	"strings"
+	"unicode"
+)
+
+// MatchEvent reports whether the event activates the route and returns the payload.
+func MatchEvent(route Route, event Event) (string, bool) {
+	if route.Device != "" && !strings.EqualFold(route.Device, event.DeviceName) {
+		return "", false
+	}
+
+	normalizedRaw := normalizePhrase(event.RawText)
+	for _, ignore := range route.Ignore {
+		if normalizedRaw == ignore || strings.HasPrefix(normalizedRaw, ignore+" ") {
+			return "", false
+		}
+	}
+
+	normalizedText := normalizePhrase(event.Text)
+	normalizedPhrase := normalizePhrase(route.Phrase)
+
+	var payload string
+	switch route.Match {
+	case MatchContains:
+		idx := strings.Index(normalizedText, normalizedPhrase)
+		if idx < 0 {
+			return "", false
+		}
+		payload = strings.TrimSpace(normalizedText[idx+len(normalizedPhrase):])
+	default:
+		if normalizedText == normalizedPhrase {
+			payload = ""
+			break
+		}
+		if !strings.HasPrefix(normalizedText, normalizedPhrase+" ") {
+			return "", false
+		}
+		payload = strings.TrimSpace(normalizedText[len(normalizedPhrase):])
+	}
+
+	payload = trimFiller(payload)
+	if payload == "" {
+		return "", false
+	}
+	return payload, true
+}
+
+func normalizePhrase(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastSpace := true
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			b.WriteRune(r)
+			lastSpace = false
+		case unicode.IsSpace(r):
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		case strings.ContainsRune("',.!?:;\"-_/()", r):
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		default:
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func trimFiller(value string) string {
+	value = strings.TrimSpace(value)
+	for _, prefix := range []string{
+		"please ",
+		"can you ",
+		"could you ",
+		"would you ",
+		"hey ",
+		"um ",
+		"uh ",
+	} {
+		if strings.HasPrefix(value, prefix) {
+			value = strings.TrimSpace(strings.TrimPrefix(value, prefix))
+		}
+	}
+	return value
+}

--- a/internal/watch/runner.go
+++ b/internal/watch/runner.go
@@ -1,0 +1,280 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/buddyh/alexa-cli/internal/api"
+)
+
+// Runner executes configured phrase routes against Alexa history/conversations.
+type Runner struct {
+	Client *api.Client
+	Config *Config
+	State  *State
+
+	initialSeeded bool
+}
+
+// Run executes the watcher loop until the context is cancelled.
+func (r *Runner) Run(ctx context.Context) error {
+	if r.Client == nil {
+		return fmt.Errorf("client is required")
+	}
+	if r.Config == nil {
+		return fmt.Errorf("config is required")
+	}
+	if r.State == nil {
+		r.State = NewState()
+	}
+	if len(r.Config.Routes) == 0 {
+		return fmt.Errorf("no routes configured")
+	}
+
+	if _, err := r.Client.GetDevices(); err != nil {
+		return fmt.Errorf("failed to load devices: %w", err)
+	}
+
+	if err := r.poll(true); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(r.Config.PollEvery())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := r.poll(false); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (r *Runner) poll(seedOnly bool) error {
+	deviceMap, err := r.deviceMap()
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+	conversationsLoaded := false
+	var conversations []api.Conversation
+
+	for _, route := range r.Config.Routes {
+		sources := sourcesForRoute(route)
+		for _, source := range sources {
+			switch source {
+			case SourceConversation:
+				if !conversationsLoaded {
+					conversations, err = r.Client.GetConversations()
+					conversationsLoaded = true
+					if err != nil {
+						if firstErr == nil {
+							firstErr = fmt.Errorf("conversation poll failed: %w", err)
+						}
+						continue
+					}
+				}
+				if err := r.pollConversationRoute(route, conversations, seedOnly); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			case SourceHistory:
+				if err := r.pollHistoryRoute(route, deviceMap, seedOnly); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+	}
+
+	if err := r.State.Save(); err != nil {
+		return err
+	}
+	if seedOnly {
+		r.initialSeeded = true
+	}
+	return firstErr
+}
+
+func (r *Runner) pollHistoryRoute(route Route, deviceMap map[string]api.Device, seedOnly bool) error {
+	end := time.Now().UnixMilli()
+	start := end - int64((2*time.Minute)/time.Millisecond)
+
+	records, err := r.Client.GetCustomerHistoryRecords(start, end)
+	if err != nil {
+		return err
+	}
+
+	for _, record := range records {
+		key := record.RecordKey
+		if _, ok := r.State.SeenHistory[key]; ok {
+			continue
+		}
+
+		deviceName := record.Device
+		if dev, ok := deviceMap[record.Device]; ok {
+			deviceName = dev.AccountName
+		}
+
+		r.State.SeenHistory[key] = record.Timestamp
+		if seedOnly || record.CustomerUtterance == "" {
+			continue
+		}
+
+		event := Event{
+			Source:       SourceHistory,
+			RouteSource:  route.Source,
+			Key:          key,
+			DeviceName:   deviceName,
+			DeviceSerial: record.Device,
+			Timestamp:    time.UnixMilli(record.Timestamp),
+			Text:         record.CustomerUtterance,
+			RawText:      record.CustomerUtterance,
+		}
+		if err := r.handleRouteEvent(route, event); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *Runner) pollConversationRoute(route Route, conversations []api.Conversation, seedOnly bool) error {
+	for _, conversation := range conversations {
+		if route.Device != "" && !strings.EqualFold(route.Device, conversation.DeviceName) {
+			continue
+		}
+
+		r.Client.SetConversationID(conversation.ConversationID)
+		resp, err := r.Client.GetConversationFragments()
+		if err != nil {
+			return err
+		}
+
+		for _, fragment := range resp.Fragments {
+			if fragment.Metadata.Purpose != "USER" || fragment.Content == nil {
+				continue
+			}
+			text := fragment.Content.GetText()
+			if text == "" {
+				continue
+			}
+			if _, ok := r.State.SeenConversation[fragment.FragmentURI]; ok {
+				continue
+			}
+
+			r.State.SeenConversation[fragment.FragmentURI] = conversation.ConversationID
+			if seedOnly {
+				continue
+			}
+
+			ts, _ := time.Parse(time.RFC3339, fragment.Timestamp)
+			if ts.IsZero() {
+				ts = time.Now()
+			}
+
+			event := Event{
+				Source:       SourceConversation,
+				RouteSource:  route.Source,
+				Key:          fragment.FragmentURI,
+				Conversation: conversation.ConversationID,
+				DeviceName:   conversation.DeviceName,
+				Timestamp:    ts,
+				Text:         text,
+				RawText:      text,
+			}
+			if err := r.handleRouteEvent(route, event); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Runner) handleRouteEvent(route Route, event Event) error {
+	payload, matched := MatchEvent(route, event)
+	if !matched {
+		return nil
+	}
+
+	switch route.Action.Type {
+	case ActionOpenClaw:
+		args := []string{"agent", "--message", payload}
+		if route.Action.Agent != "" {
+			args = append(args, "--agent", route.Action.Agent)
+		}
+		cmd := exec.Command("openclaw", args...)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("openclaw dispatch failed for route %s: %w (%s)", route.ID, err, strings.TrimSpace(string(output)))
+		}
+	case ActionExec:
+		command := strings.ReplaceAll(route.Action.Command, "{{text}}", payload)
+		cmd := exec.Command("/bin/sh", "-c", command)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("exec action failed for route %s: %w (%s)", route.ID, err, strings.TrimSpace(string(output)))
+		}
+	case ActionStdout:
+		fmt.Printf("[%s] %s -> %s\n", event.Timestamp.Format(time.RFC3339), route.Phrase, payload)
+	default:
+		return fmt.Errorf("unsupported action type %q", route.Action.Type)
+	}
+
+	if route.Ack != nil && route.Ack.Text != "" {
+		if err := r.speakAck(route, event); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *Runner) speakAck(route Route, event Event) error {
+	deviceName := route.Device
+	if deviceName == "" {
+		deviceName = event.DeviceName
+	}
+	if deviceName == "" {
+		return nil
+	}
+
+	devices, err := r.Client.GetDevices()
+	if err != nil {
+		return err
+	}
+	for i := range devices {
+		if strings.EqualFold(devices[i].AccountName, deviceName) || devices[i].SerialNumber == event.DeviceSerial {
+			return r.Client.SequenceCommand(&devices[i], fmt.Sprintf("speak:%q", route.Ack.Text))
+		}
+	}
+	return nil
+}
+
+func (r *Runner) deviceMap() (map[string]api.Device, error) {
+	devices, err := r.Client.GetDevices()
+	if err != nil {
+		return nil, err
+	}
+	bySerial := make(map[string]api.Device, len(devices))
+	for _, device := range devices {
+		bySerial[device.SerialNumber] = device
+	}
+	return bySerial, nil
+}
+
+func sourcesForRoute(route Route) []Source {
+	switch route.Source {
+	case SourceConversation:
+		return []Source{SourceConversation}
+	case SourceHistory:
+		return []Source{SourceHistory}
+	default:
+		return []Source{SourceConversation, SourceHistory}
+	}
+}


### PR DESCRIPTION
Adds the alexa-poller companion binary for route-based Alexa activation phrase automation, documents its setup, and adds focused tests for route config, matching, CLI route management, and destination parsing.\n\nVerification:\n- go test ./...\n- go test -count=1 ./...\n- go test -race ./...\n- go vet ./...\n- make build-tools\n- gofmt -l cmd internal\n- ./bin/alexacli --version\n- ./bin/alexa-poller --version\n- ./bin/alexa-poller route add --help